### PR TITLE
Bring back Exchange2

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -157,6 +157,10 @@ PRODUCT_PACKAGES += \
     CMSettingsProvider \
     ExactCalculator
 
+# Exchange support
+PRODUCT_PACKAGES += \
+    Exchange2
+
 # CM Platform Library
 PRODUCT_PACKAGES += \
     org.cyanogenmod.platform-res \


### PR DESCRIPTION
Dropped out via r22, but we want this

Change-Id: Iec52790d7c69594d1101d9062fb649a3aca866ab